### PR TITLE
Do not update typescript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "prettier": "^3.3.2",
         "replace-in-files-cli": "^2.2.0",
         "rimraf": "^5.0.7",
-        "typescript": "^5.4.5",
+        "typescript": "~5.4.5",
         "vitest": "^1.6.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prettier": "^3.3.2",
     "replace-in-files-cli": "^2.2.0",
     "rimraf": "^5.0.7",
-    "typescript": "^5.4.5",
+    "typescript": "~5.4.5",
     "vitest": "^1.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Since this plugin would not support typedoc 0.26, which is the first version of typedoc that supports typescript 5.5.