### PR TITLE
Do not allow update typedoc-plugin-plausible beyond 2.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,10 @@
     {
       "matchPackageNames": ["typedoc"],
       "allowedVersions": "<0.26.0"
+    },
+    {
+      "matchPackageNames": ["typedoc-plugin-plausible"],
+      "allowedVersions": "<2.0.0"
     }
   ]
 }


### PR DESCRIPTION
Because we don't support typedoc 0.26+.